### PR TITLE
Remove unnecessary space

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,5 +111,5 @@ function writeToTerminal(command, options = {}) {
     let esc = options.esc ? `\x1B` : `\x03`
     let enter = options.promptUser ? `` : `\x0D`
 
-    currentWindow.sessions.get(currentUid).write(`${esc} ${command}${enter}`);
+    currentWindow.sessions.get(currentUid).write(`${esc}${command}${enter}`);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16443111/78295983-a29aec80-7535-11ea-8a19-1f15f4101cc8.png)
Currently, the plugin prints the command with a space before.